### PR TITLE
Optional argument support for smolagents

### DIFF
--- a/src/mcpadapt/smolagents_adapter.py
+++ b/src/mcpadapt/smolagents_adapter.py
@@ -32,7 +32,7 @@ def _generate_tool_inputs(resolved_json_schema: dict[str, Any]) -> dict[str, dic
             "description": v.get("description", "") # TODO: use google-docstring-parser to parse description of args and pass it here...
         }
         if "default" in v:
-            inputs[k]["default"] = str(v["default"])
+            inputs[k]["default"] = f'"{v["default"]}"' if isinstance(v["default"], str) else str(v["default"])
             inputs[k]["nullable"] = "True"
     return inputs
    

--- a/src/mcpadapt/smolagents_adapter.py
+++ b/src/mcpadapt/smolagents_adapter.py
@@ -18,7 +18,9 @@ import smolagents
 from mcpadapt.core import ToolAdapter
 
 
-def _generate_tool_inputs(resolved_json_schema: dict[str, Any]) -> dict[str, dict[str, str]]:
+def _generate_tool_inputs(
+    resolved_json_schema: dict[str, Any],
+) -> dict[str, dict[str, str]]:
     """
     takes an json_schema as used in the MCP protocol and return an inputs dict for
     smolagents tools. see AUTHORIZED_TYPES in smolagents.tools for the types allowed.
@@ -29,14 +31,20 @@ def _generate_tool_inputs(resolved_json_schema: dict[str, Any]) -> dict[str, dic
     for k, v in resolved_json_schema.items():
         inputs[k] = {
             "type": v.get("type") or v.get("anyOf")[0].get("type"),
-            "description": v.get("description", "") # TODO: use google-docstring-parser to parse description of args and pass it here...
+            "description": v.get(
+                "description", ""
+            ),  # TODO: use google-docstring-parser to parse description of args and pass it here...
         }
         if "default" in v:
-            inputs[k]["default"] = f'"{v["default"]}"' if isinstance(v["default"], str) else str(v["default"])
+            inputs[k]["default"] = (
+                f'"{v["default"]}"'
+                if isinstance(v["default"], str)
+                else str(v["default"])
+            )
             inputs[k]["nullable"] = "True"
     return inputs
-   
-   
+
+
 def _generate_tool_class(
     name: str,
     description: str,

--- a/src/mcpadapt/smolagents_adapter.py
+++ b/src/mcpadapt/smolagents_adapter.py
@@ -18,20 +18,25 @@ import smolagents
 from mcpadapt.core import ToolAdapter
 
 
-def _generate_tool_inputs(resolved_json_schema: dict[str, Any]) -> dict[str, str]:
+def _generate_tool_inputs(resolved_json_schema: dict[str, Any]) -> dict[str, dict[str, str]]:
     """
     takes an json_schema as used in the MCP protocol and return an inputs dict for
     smolagents tools. see AUTHORIZED_TYPES in smolagents.tools for the types allowed.
     Note that we consider the json_schema to already have $ref resolved with jsonref for
     example.
     """
-    return {
-        # TODO: use google-docstring-parser to parse description of args and pass it here...
-        k: {"type": v["type"], "description": v.get("description", "")}
-        for k, v in resolved_json_schema.items()
-    }
-
-
+    inputs: dict[str, dict[str, str]] = {}
+    for k, v in resolved_json_schema.items():
+        inputs[k] = {
+            "type": v.get("type") or v.get("anyOf")[0].get("type"),
+            "description": v.get("description", "") # TODO: use google-docstring-parser to parse description of args and pass it here...
+        }
+        if "default" in v:
+            inputs[k]["default"] = str(v["default"])
+            inputs[k]["nullable"] = "True"
+    return inputs
+   
+   
 def _generate_tool_class(
     name: str,
     description: str,
@@ -61,7 +66,10 @@ def _generate_tool_class(
 
     # smolagents provide arguments to the forward as follow forward(arg1=..., arg2=...)
     # but MCP call_tool takes a single 'argument' as in func({'arg1': .., 'arg2': ..})
-    forward_params = ", ".join(f"{k}" for k in smolagents_inputs.keys())
+    forward_params = ", ".join(
+        f"{k}={v['default']}" if "default" in v else f"{k}"
+        for k, v in smolagents_inputs.items()
+    )
     argument = "{" + ", ".join(f"'{k}': {k}" for k in smolagents_inputs.keys()) + "}"
 
     class_template = f'''

--- a/tests/test_smolagents_adapter.py
+++ b/tests/test_smolagents_adapter.py
@@ -44,6 +44,31 @@ def echo_server_sse_script():
 
 
 @pytest.fixture
+def echo_server_optional_script():
+    return dedent(
+        '''
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("Echo Server")
+
+        @mcp.tool()
+        def echo_tool_optional(text: str | None = None) -> str:
+            """Echo the input text, or return a default message if no text is provided"""
+            if text is None:
+                return "No input provided"
+            return f"Echo: {text}"
+
+        @mcp.tool()
+        def echo_tool_default_value(text: str = "empty") -> str:
+            """Echo the input text, default to 'empty' if no text is provided"""
+            return f"Echo: {text}"
+        
+        mcp.run()
+        '''
+    )
+
+
+@pytest.fixture
 async def echo_sse_server(echo_server_sse_script):
     import subprocess
     import time
@@ -85,3 +110,19 @@ def test_basic_sync_sse(echo_sse_server):
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
         assert tools[0]("hello") == "Echo: hello"
+
+
+def test_optional_sync(echo_server_optional_script):
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv", args=["run", "python", "-c", echo_server_optional_script]
+        ),
+        SmolAgentsAdapter(),
+    ) as tools:
+        assert len(tools) == 2
+        assert tools[0].name == "echo_tool_optional"
+        assert tools[0]("hello") == "Echo: hello"
+        assert tools[0]() == "No input provided"
+        assert tools[1].name == "echo_tool_default_value"
+        assert tools[1]("hello") == "Echo: hello"
+        assert tools[1]() == "Echo: empty"

--- a/tests/test_smolagents_adapter.py
+++ b/tests/test_smolagents_adapter.py
@@ -62,6 +62,13 @@ def echo_server_optional_script():
         def echo_tool_default_value(text: str = "empty") -> str:
             """Echo the input text, default to 'empty' if no text is provided"""
             return f"Echo: {text}"
+
+        @mcp.tool()
+        def echo_tool_union_none(text: str | None) -> str:
+            """Echo the input text, but None is not specified by default."""
+            if text is None:
+                return "No input provided"
+            return f"Echo: {text}"
         
         mcp.run()
         '''
@@ -119,10 +126,12 @@ def test_optional_sync(echo_server_optional_script):
         ),
         SmolAgentsAdapter(),
     ) as tools:
-        assert len(tools) == 2
+        assert len(tools) == 3
         assert tools[0].name == "echo_tool_optional"
         assert tools[0]("hello") == "Echo: hello"
         assert tools[0]() == "No input provided"
         assert tools[1].name == "echo_tool_default_value"
         assert tools[1]("hello") == "Echo: hello"
         assert tools[1]() == "Echo: empty"
+        assert tools[2].name == "echo_tool_union_none"
+        assert tools[2]("hello") == "Echo: hello"


### PR DESCRIPTION
Fixes This PR resolves the error in issue #10 (related https://github.com/huggingface/smolagents/issues/626 )

Error output
```sh
k: {"type": v["type"], "description": v.get("description", "")}
KeyError: 'type'
```

The fix addresses cases where arguments are provided using the `anyOf` schema.

## Changed
 - Implemented support for handling functions with optional arguments when defined as Tools (primarily using FastMCP)
 - Added tests for the modified functionality

## Implementation approach for optional and default arguments
I've addressed three scenarios related to issue.

1. Optional arguments with None as default: `text: str | None = None`
2. Required arguments with default values: `text: str = "hello"`
3. Optional arguments without default values: `text: str | None`

The current implementation outputs the following forward function for each case
```py
# case1
def forward(self, text=None) -> str:
   ...
   
# case2
def forward(self, text="hello") -> str:
   ...

# case3
def forward(self, text) -> str:
   ...
```

For optional arguments without default values (case 3), I chose to maintain the existing implementation approach, requiring CodeAgent to explicitly specify these values rather than automatically providing None. But I'm open to discussion on this design choice.

Thank you for reviewing this PR!
