### PR TITLE
Handle oneOf schema validation in _generate_tool_inputs for SmolAgents 

### DIFF
--- a/src/mcpadapt/smolagents_adapter.py
+++ b/src/mcpadapt/smolagents_adapter.py
@@ -29,8 +29,26 @@ def _generate_tool_inputs(
     """
     inputs: dict[str, dict[str, str]] = {}
     for k, v in resolved_json_schema.items():
+        # Get type from direct type field, anyOf, or oneOf, handling None cases
+        type_value = v.get("type")
+        if type_value is None:
+            # Try anyOf
+            anyOf = v.get("anyOf")
+            if anyOf and len(anyOf) > 0:
+                type_value = anyOf[0].get("type")
+            
+            # If still None, try oneOf
+            if type_value is None:
+                oneOf = v.get("oneOf")
+                if oneOf and len(oneOf) > 0:
+                    type_value = oneOf[0].get("type")
+        
+        # Default to "string" if we still couldn't find a type
+        if type_value is None:
+            type_value = "string"
+            
         inputs[k] = {
-            "type": v.get("type") or v.get("anyOf")[0].get("type"),
+            "type": type_value,
             "description": v.get(
                 "description", ""
             ),  # TODO: use google-docstring-parser to parse description of args and pass it here...


### PR DESCRIPTION
While using the firecrawl-mcp-server with Smolagents I found that mcpadapt could not generate all the inputs from the definitions the server sends. 

I tracked down the problem to the _generate_tool_inputs function where I think some details in the implementation where missing. I asked my friend Claude 3.7 to update the lines. Checked manually and performed a few tests. 