### PR TITLE
Allow multiple MCPs to be passed at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ with MCPAdapt(
 
 We also support async if the underlying agentic framework supports it.
 
-See our [examples]() for more details on how to use.
+See our [examples](https://grll.github.io/mcpadapt/quickstart/#examples) for more details on how to use.
 
 ## Contribute
 
@@ -168,3 +168,4 @@ Contributors:
 * [@murawakimitsuhiro](https://github.com/murawakimitsuhiro)
 * [@joejoe2](https://github.com/joejoe2)
 * [@tisDDM](https://github.com/tisDDM)
+* [@sysradium](https://github.com/sysradium)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,27 @@ with MCPAdapt(
 MCP Adapt supports Smolagents, Langchain, CrewAI, google-genai [pydantic.dev, Llammaindex and more...]*.
 *coming soon.
 
-See our examples for more details on how to use.
+Note: you can also specify multiple mcp servers as in:
+
+```python
+from mcp import StdioServerParameters
+from mcpadapt.core import MCPAdapt
+from mcpadapt.smolagents_adapter import SmolAgentsAdapter
+
+with MCPAdapt(
+    [
+        StdioServerParameters(command="uv", args=["run", "src/echo1.py"]),
+        StdioServerParameters(command="uv", args=["run", "src/echo2.py"]),
+    ],
+    SmolAgentsAdapter(),
+) as tools:
+    # tools is now a flattened list of tools from the 2 MCP servers.
+    ...
+```
+
+We also support async if the underlying agentic framework supports it.
+
+See our [examples]() for more details on how to use.
 
 ## Contribute
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,3 +107,4 @@ Contributors:
 * [@murawakimitsuhiro](https://github.com/murawakimitsuhiro)
 * [@joejoe2](https://github.com/joejoe2)
 * [@tisDDM](https://github.com/tisDDM)
+* [@sysradium](https://github.com/sysradium)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -99,7 +99,7 @@ In all cases, you can provide multiple MCP Server parameters as a list:
 ```python
 from mcp import StdioServerParameters
 from mcpadapt.core import MCPAdapt
-from mcpadapt.smolagents_adapter import SmolAgentsAdapter
+from mcpadapt.<framework>_adapter import <Framework>Adapter
 
 with MCPAdapt(
     [

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -92,6 +92,26 @@ To use SSE, simply provide a configuration dictionary instead of StdioServerPara
 
 These parameters are passed directly to the MCP Python SDK's SSE client. For more details, see the [official MCP Python SDK documentation](https://github.com/modelcontextprotocol/python-sdk/blob/c2ca8e03e046908935d089a2ceed4e80b0c29a24/src/mcp/client/sse.py#L22C11-L22C21).
 
+### Multiple MCP Servers
+
+In all cases, you can provide multiple MCP Server parameters as a list:
+
+```python
+from mcp import StdioServerParameters
+from mcpadapt.core import MCPAdapt
+from mcpadapt.smolagents_adapter import SmolAgentsAdapter
+
+with MCPAdapt(
+    [
+        StdioServerParameters(command="uv", args=["run", "src/echo1.py"]),
+        StdioServerParameters(command="uv", args=["run", "src/echo2.py"]),
+    ],
+    <AgenticFramework>Adapter(),
+) as tools:
+    # tools is now a flattened list of tools from the 2 MCP servers.
+    ...
+```
+
 ## Examples
 
 We provide guided examples of usage for each framework in their respective guides:

--- a/src/mcpadapt/core.py
+++ b/src/mcpadapt/core.py
@@ -9,7 +9,7 @@ import threading
 from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack, asynccontextmanager
 from functools import partial
-from typing import Any, Callable, Coroutine
+from typing import Any, AsyncGenerator, Callable, Coroutine
 
 import mcp
 from mcp import ClientSession, StdioServerParameters
@@ -71,7 +71,7 @@ class ToolAdapter(ABC):
 @asynccontextmanager
 async def mcptools(
     serverparams: StdioServerParameters | dict[str, Any],
-) -> tuple[ClientSession, list[mcp.types.Tool]]:
+) -> AsyncGenerator[tuple[ClientSession, list[mcp.types.Tool]]]:
     """Async context manager that yields tools from an MCP server.
 
     Note: the session can be then used to call tools on the MCP server but it's async.
@@ -141,8 +141,7 @@ class MCPAdapt:
         self,
         serverparams: StdioServerParameters
         | dict[str, Any]
-        | list[StdioServerParameters]
-        | list[dict[str, Any]],
+        | list[StdioServerParameters | dict[str, Any]],
         adapter: ToolAdapter,
         connect_timeout: int = 30,
     ):

--- a/src/mcpadapt/core.py
+++ b/src/mcpadapt/core.py
@@ -276,16 +276,16 @@ if __name__ == "__main__":
     with MCPAdapt(
         StdioServerParameters(command="uv", args=["run", "src/echo.py"]),
         DummyAdapter(),
-    ) as smolagents_tools:
-        print(smolagents_tools)
-        print(smolagents_tools[0].forward({"text": "hello"}))
+    ) as dummy_tools:
+        print(dummy_tools)
+        print(dummy_tools[0]({"text": "hello"}))
 
     async def main():
         async with MCPAdapt(
             StdioServerParameters(command="uv", args=["run", "src/echo.py"]),
             DummyAdapter(),
-        ) as smolagents_tools:
-            print(smolagents_tools)
-            print(smolagents_tools[0].forward({"text": "hello"}))
+        ) as dummy_tools:
+            print(dummy_tools)
+            print(await dummy_tools[0]({"text": "hello"}))
 
     asyncio.run(main())

--- a/src/mcpadapt/core.py
+++ b/src/mcpadapt/core.py
@@ -71,7 +71,7 @@ class ToolAdapter(ABC):
 @asynccontextmanager
 async def mcptools(
     serverparams: StdioServerParameters | dict[str, Any],
-) -> AsyncGenerator[tuple[ClientSession, list[mcp.types.Tool]]]:
+) -> AsyncGenerator[tuple[ClientSession, list[mcp.types.Tool]], None]:
     """Async context manager that yields tools from an MCP server.
 
     Note: the session can be then used to call tools on the MCP server but it's async.

--- a/src/mcpadapt/core.py
+++ b/src/mcpadapt/core.py
@@ -7,7 +7,7 @@ basic interfaces and classes for adapting tools from MCP to the desired Agent fr
 import asyncio
 import threading
 from abc import ABC, abstractmethod
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from functools import partial
 from typing import Any, Callable, Coroutine
 
@@ -139,7 +139,10 @@ class MCPAdapt:
 
     def __init__(
         self,
-        serverparams: StdioServerParameters | dict[str, Any],
+        serverparams: StdioServerParameters
+        | dict[str, Any]
+        | list[StdioServerParameters]
+        | list[dict[str, Any]],
         adapter: ToolAdapter,
         connect_timeout: int = 30,
     ):
@@ -147,42 +150,46 @@ class MCPAdapt:
         Manage the MCP server / client lifecycle and expose tools adapted with the adapter.
 
         Args:
-            serverparams (StdioServerParameters | dict[str, Any]): MCP server parameters (stdio or sse).
+            serverparams (StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]):
+                MCP server parameters (stdio or sse). Can be a list of you want to connect multiple MCPs at once.
             adapter (ToolAdapter): Adapter to use to convert MCP tools call into agentic framework tools.
             connect_timeout (int): Connection timeout in seconds to the mcp server (default is 30s).
 
         Raises:
             TimeoutError: When the connection to the mcp server time out.
         """
-        # attributes we receive from the user.
-        self.serverparams = serverparams
+
+        if isinstance(serverparams, list):
+            self.serverparams = serverparams
+        else:
+            self.serverparams = [serverparams]
+
         self.adapter = adapter
 
         # session and tools get set by the async loop during initialization.
-        self.session: ClientSession | None = None
-        self.mcp_tools: list[mcp.types.Tool] | None = None
+        self.sessions: list[ClientSession] = []
+        self.mcp_tools: list[mcp.types.Tool] = []
 
         # all attributes used to manage the async loop and separate thread.
         self.loop = asyncio.new_event_loop()
         self.task = None
+
         self.ready = threading.Event()
         self.thread = threading.Thread(target=self._run_loop, daemon=True)
 
-        # start the loop in a separate thread and wait till ready synchronously.
-        self.thread.start()
-        # check connection to mcp server is ready
-        if not self.ready.wait(timeout=connect_timeout):
-            raise TimeoutError(
-                f"Couldn't connect to the MCP server after {connect_timeout} seconds"
-            )
+        self.connect_timeout = connect_timeout
 
     def _run_loop(self):
         """Runs the event loop in a separate thread (for synchronous usage)."""
         asyncio.set_event_loop(self.loop)
 
         async def setup():
-            async with mcptools(self.serverparams) as (session, tools):
-                self.session, self.mcp_tools = session, tools
+            async with AsyncExitStack() as stack:
+                connections = [
+                    await stack.enter_async_context(mcptools(params))
+                    for params in self.serverparams
+                ]
+                self.sessions, self.mcp_tools = [list(c) for c in zip(*connections)]
                 self.ready.set()  # Signal initialization is complete
                 await asyncio.Event().wait()  # Keep session alive until stopped
 
@@ -202,19 +209,20 @@ class MCPAdapt:
         see :meth:`atools`.
 
         """
-        if not self.session:
+        if not self.sessions:
             raise RuntimeError("Session not initialized")
 
         def _sync_call_tool(
-            name: str, arguments: dict | None = None
+            session, name: str, arguments: dict | None = None
         ) -> mcp.types.CallToolResult:
             return asyncio.run_coroutine_threadsafe(
-                self.session.call_tool(name, arguments), self.loop
+                session.call_tool(name, arguments), self.loop
             ).result()
 
         return [
-            self.adapter.adapt(partial(_sync_call_tool, tool.name), tool)
-            for tool in self.mcp_tools
+            self.adapter.adapt(partial(_sync_call_tool, session, tool.name), tool)
+            for session, tools in zip(self.sessions, self.mcp_tools)
+            for tool in tools
         ]
 
     def close(self):
@@ -225,6 +233,14 @@ class MCPAdapt:
         self.loop.close()  # we won't be using the loop anymore we can safely close it
 
     def __enter__(self):
+        self.thread.start()
+
+        # check connection to mcp server is ready
+        if not self.ready.wait(timeout=self.connect_timeout):
+            raise TimeoutError(
+                f"Couldn't connect to the MCP server after {self.connect_timeout} seconds"
+            )
+
         return self.tools()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -241,13 +257,21 @@ class MCPAdapt:
         see :meth:`atools`.
         """
         return [
-            self.adapter.async_adapt(partial(self.session.call_tool, tool.name), tool)
-            for tool in self.mcp_tools
+            self.adapter.async_adapt(partial(session.call_tool, tool.name), tool)
+            for session, tools in zip(self.sessions, self.mcp_tools)
+            for tool in tools
         ]
 
     async def __aenter__(self) -> list[Any]:
-        self._ctxmanager = mcptools(self.serverparams)
-        self.session, self.tools = await self._ctxmanager.__aenter__()
+        self._ctxmanager = AsyncExitStack()
+
+        connections = [
+            await self._ctxmanager.enter_async_context(mcptools(params))
+            for params in self.serverparams
+        ]
+
+        self.sessions, self.mcp_tools = [list(c) for c in zip(*connections)]
+
         return self.atools()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
@@ -274,18 +298,26 @@ if __name__ == "__main__":
             return afunc
 
     with MCPAdapt(
-        StdioServerParameters(command="uv", args=["run", "src/echo.py"]),
+        [
+            StdioServerParameters(command="uv", args=["run", "src/echo.py"]),
+            StdioServerParameters(command="uv", args=["run", "src/echo.py"]),
+        ],
         DummyAdapter(),
     ) as dummy_tools:
         print(dummy_tools)
         print(dummy_tools[0]({"text": "hello"}))
+        print(dummy_tools[1]({"text": "world"}))
 
     async def main():
         async with MCPAdapt(
-            StdioServerParameters(command="uv", args=["run", "src/echo.py"]),
+            [
+                StdioServerParameters(command="uv", args=["run", "src/echo.py"]),
+                StdioServerParameters(command="uv", args=["run", "src/echo.py"]),
+            ],
             DummyAdapter(),
         ) as dummy_tools:
             print(dummy_tools)
             print(await dummy_tools[0]({"text": "hello"}))
+            print(await dummy_tools[1]({"text": "world"}))
 
     asyncio.run(main())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -61,6 +61,7 @@ def echo_server_sse_script():
         '''
     )
 
+
 @pytest.fixture
 async def echo_sse_server(echo_server_sse_script):
     import subprocess
@@ -81,6 +82,7 @@ async def echo_sse_server(echo_server_sse_script):
         process.kill()
         process.wait()
 
+
 def test_basic_sync(echo_server_script):
     with MCPAdapt(
         StdioServerParameters(
@@ -90,6 +92,7 @@ def test_basic_sync(echo_server_script):
     ) as tools:
         assert len(tools) == 1
         assert tools[0]({"text": "hello"}).content[0].text == "Echo: hello"
+
 
 def test_basic_sync_multiple_tools(echo_server_script):
     with MCPAdapt(
@@ -107,6 +110,7 @@ def test_basic_sync_multiple_tools(echo_server_script):
         assert tools[0]({"text": "hello"}).content[0].text == "Echo: hello"
         assert tools[1]({"text": "world"}).content[0].text == "Echo: world"
 
+
 async def test_basic_async(echo_server_script):
     async with MCPAdapt(
         StdioServerParameters(
@@ -117,7 +121,8 @@ async def test_basic_async(echo_server_script):
         assert len(tools) == 1
         mcp_tool_call_result = await tools[0]({"text": "hello"})
         assert mcp_tool_call_result.content[0].text == "Echo: hello"
-    
+
+
 async def test_basic_async_multiple_tools(echo_server_script):
     async with MCPAdapt(
         [
@@ -136,6 +141,7 @@ async def test_basic_async_multiple_tools(echo_server_script):
         mcp_tool_call_result = await tools[1]({"text": "world"})
         assert mcp_tool_call_result.content[0].text == "Echo: world"
 
+
 def test_basic_sync_sse(echo_sse_server):
     sse_serverparams = echo_sse_server
     with MCPAdapt(
@@ -144,6 +150,7 @@ def test_basic_sync_sse(echo_sse_server):
     ) as tools:
         assert len(tools) == 1
         assert tools[0]({"text": "hello"}).content[0].text == "Echo: hello"
+
 
 def test_basic_sync_multiple_sse(echo_sse_server):
     sse_serverparams = echo_sse_server
@@ -155,6 +162,7 @@ def test_basic_sync_multiple_sse(echo_sse_server):
         assert tools[0]({"text": "hello"}).content[0].text == "Echo: hello"
         assert tools[1]({"text": "world"}).content[0].text == "Echo: world"
 
+
 async def test_basic_async_sse(echo_sse_server):
     sse_serverparams = echo_sse_server
     async with MCPAdapt(
@@ -164,6 +172,7 @@ async def test_basic_async_sse(echo_sse_server):
         assert len(tools) == 1
         mcp_tool_call_result = await tools[0]({"text": "hello"})
         assert mcp_tool_call_result.content[0].text == "Echo: hello"
+
 
 async def test_basic_async_multiple_sse(echo_sse_server):
     sse_serverparams = echo_sse_server

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,178 @@
+from textwrap import dedent
+from typing import Any, Callable, Coroutine
+
+import mcp
+import pytest
+from mcp import StdioServerParameters
+
+from mcpadapt.core import MCPAdapt, ToolAdapter
+
+
+class DummyAdapter(ToolAdapter):
+    """A dummy adapter that returns the function as is"""
+
+    def adapt(
+        self,
+        func: Callable[[dict | None], mcp.types.CallToolResult],
+        mcp_tool: mcp.types.Tool,
+    ):
+        return func
+
+    def async_adapt(
+        self,
+        afunc: Callable[[dict | None], Coroutine[Any, Any, mcp.types.CallToolResult]],
+        mcp_tool: mcp.types.Tool,
+    ):
+        return afunc
+
+
+@pytest.fixture
+def echo_server_script():
+    return dedent(
+        '''
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("Echo Server")
+
+        @mcp.tool()
+        def echo_tool(text: str) -> str:
+            """Echo the input text"""
+            return f"Echo: {text}"
+        
+        mcp.run()
+        '''
+    )
+
+
+@pytest.fixture
+def echo_server_sse_script():
+    return dedent(
+        '''
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("Echo Server", host="127.0.0.1", port=8000)
+
+        @mcp.tool()
+        def echo_tool(text: str) -> str:
+            """Echo the input text"""
+            return f"Echo: {text}"
+
+        mcp.run("sse")
+        '''
+    )
+
+@pytest.fixture
+async def echo_sse_server(echo_server_sse_script):
+    import subprocess
+    import time
+
+    # Start the SSE server process with its own process group
+    process = subprocess.Popen(
+        ["python", "-c", echo_server_sse_script],
+    )
+
+    # Give the server a moment to start up
+    time.sleep(1)
+
+    try:
+        yield {"url": "http://127.0.0.1:8000/sse"}
+    finally:
+        # Clean up the process when test is done
+        process.kill()
+        process.wait()
+
+def test_basic_sync(echo_server_script):
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv", args=["run", "python", "-c", echo_server_script]
+        ),
+        DummyAdapter(),
+    ) as tools:
+        assert len(tools) == 1
+        assert tools[0]({"text": "hello"}).content[0].text == "Echo: hello"
+
+def test_basic_sync_multiple_tools(echo_server_script):
+    with MCPAdapt(
+        [
+            StdioServerParameters(
+                command="uv", args=["run", "python", "-c", echo_server_script]
+            ),
+            StdioServerParameters(
+                command="uv", args=["run", "python", "-c", echo_server_script]
+            ),
+        ],
+        DummyAdapter(),
+    ) as tools:
+        assert len(tools) == 2
+        assert tools[0]({"text": "hello"}).content[0].text == "Echo: hello"
+        assert tools[1]({"text": "world"}).content[0].text == "Echo: world"
+
+async def test_basic_async(echo_server_script):
+    async with MCPAdapt(
+        StdioServerParameters(
+            command="uv", args=["run", "python", "-c", echo_server_script]
+        ),
+        DummyAdapter(),
+    ) as tools:
+        assert len(tools) == 1
+        mcp_tool_call_result = await tools[0]({"text": "hello"})
+        assert mcp_tool_call_result.content[0].text == "Echo: hello"
+    
+async def test_basic_async_multiple_tools(echo_server_script):
+    async with MCPAdapt(
+        [
+            StdioServerParameters(
+                command="uv", args=["run", "python", "-c", echo_server_script]
+            ),
+            StdioServerParameters(
+                command="uv", args=["run", "python", "-c", echo_server_script]
+            ),
+        ],
+        DummyAdapter(),
+    ) as tools:
+        assert len(tools) == 2
+        mcp_tool_call_result = await tools[0]({"text": "hello"})
+        assert mcp_tool_call_result.content[0].text == "Echo: hello"
+        mcp_tool_call_result = await tools[1]({"text": "world"})
+        assert mcp_tool_call_result.content[0].text == "Echo: world"
+
+def test_basic_sync_sse(echo_sse_server):
+    sse_serverparams = echo_sse_server
+    with MCPAdapt(
+        sse_serverparams,
+        DummyAdapter(),
+    ) as tools:
+        assert len(tools) == 1
+        assert tools[0]({"text": "hello"}).content[0].text == "Echo: hello"
+
+def test_basic_sync_multiple_sse(echo_sse_server):
+    sse_serverparams = echo_sse_server
+    with MCPAdapt(
+        [sse_serverparams, sse_serverparams],
+        DummyAdapter(),
+    ) as tools:
+        assert len(tools) == 2
+        assert tools[0]({"text": "hello"}).content[0].text == "Echo: hello"
+        assert tools[1]({"text": "world"}).content[0].text == "Echo: world"
+
+async def test_basic_async_sse(echo_sse_server):
+    sse_serverparams = echo_sse_server
+    async with MCPAdapt(
+        sse_serverparams,
+        DummyAdapter(),
+    ) as tools:
+        assert len(tools) == 1
+        mcp_tool_call_result = await tools[0]({"text": "hello"})
+        assert mcp_tool_call_result.content[0].text == "Echo: hello"
+
+async def test_basic_async_multiple_sse(echo_sse_server):
+    sse_serverparams = echo_sse_server
+    async with MCPAdapt(
+        [sse_serverparams, sse_serverparams],
+        DummyAdapter(),
+    ) as tools:
+        assert len(tools) == 2
+        mcp_tool_call_result = await tools[0]({"text": "hello"})
+        assert mcp_tool_call_result.content[0].text == "Echo: hello"
+        mcp_tool_call_result = await tools[1]({"text": "world"})
+        assert mcp_tool_call_result.content[0].text == "Echo: world"


### PR DESCRIPTION
Creating PR as mentioned in the comment here: https://github.com/huggingface/smolagents/pull/1157#issuecomment-2797155997

Also I fixed 2 problems, hopefully @grll you can clarify if I am right:

1. The example in `core.py` was incorrectly calling `forward` method like it is a SmolAgent tool, though DummyAdapter is not a SmolAgentAdapter. I think it is a simple one
2. In the `__init__` function you were calling `setup()` method in a separate thread. The problem is that due to this when used with async MCP ClientSession was initialised twice: once here https://github.com/grll/mcpadapt/blob/main/src/mcpadapt/core.py#L184 and once here https://github.com/grll/mcpadapt/blob/main/src/mcpadapt/core.py#L249
I am not sure if it is a bug or not, I decided to change that, so that the "sync" version spins up in `__enter__` and the async one in `__aenter__`. Othwerise you would see `starting echo server` twice:
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/c42c913e-6f81-4c51-ba26-73717f3ff38a" />
I don't like the fact I had to break the interface a bit `self.session -> self.sessions`. It should have been a private attribute after all, but ...
