### PR TITLE
Prevent MCP ClientSession hang

### DIFF
--- a/src/mcpadapt/core.py
+++ b/src/mcpadapt/core.py
@@ -102,11 +102,10 @@ async def mcptools(
         )
 
     timeout = None
-    if client_session_timeout_seconds is not None:
-        if isinstance(client_session_timeout_seconds, float):
-            timeout = timedelta(seconds=client_session_timeout_seconds)
-        elif isinstance(client_session_timeout_seconds, timedelta):
-            timeout = client_session_timeout_seconds
+    if isinstance(client_session_timeout_seconds, float):
+        timeout = timedelta(seconds=client_session_timeout_seconds)
+    elif isinstance(client_session_timeout_seconds, timedelta):
+        timeout = client_session_timeout_seconds
 
     async with client as (read, write):
         async with ClientSession(


### PR DESCRIPTION
Per https://modelcontextprotocol.io/specification/draft/basic/lifecycle#timeouts

"Implementations SHOULD establish timeouts for all sent requests, to prevent hung connections and resource exhaustion. When the request has not received a success or error response within the timeout period, the sender SHOULD issue a cancellation notification for that request and stop waiting for a response.

SDKs and other middleware SHOULD allow these timeouts to be configured on a per-request basis."