### PR TITLE
fix(crewai_adapter): Proper validation and filtering of None values in MCP tool calls

### DIFF
--- a/tests/test_crewai_adapter.py
+++ b/tests/test_crewai_adapter.py
@@ -8,6 +8,71 @@ from mcpadapt.crewai_adapter import CrewAIAdapter
 
 
 @pytest.fixture
+def complex_types_server_script():
+    return dedent(
+        '''
+        from mcp.server.fastmcp import FastMCP
+        from typing import Dict, List, Optional
+
+        mcp = FastMCP("Complex Types Server")
+
+        @mcp.tool()
+        def tool_with_object(config: Dict[str, str]) -> str:
+            """Tool that takes an object parameter"""
+            return f"Received config with {len(config)} keys"
+
+        @mcp.tool()
+        def tool_with_optional_object(config: Optional[Dict[str, str]] = None) -> str:
+            """Tool that takes an optional object parameter"""
+            if config is None:
+                return "No config provided"
+            return f"Received config with {len(config)} keys"
+
+        @mcp.tool()
+        def tool_with_number(value: float) -> str:
+            """Tool that takes a number parameter"""
+            return f"Received value: {value}"
+
+        @mcp.tool()
+        def tool_with_optional_number(value: Optional[float] = None) -> str:
+            """Tool that takes an optional number parameter"""
+            if value is None:
+                return "No value provided"
+            return f"Received value: {value}"
+
+        mcp.run()
+        '''
+    )
+
+
+@pytest.fixture
+def nested_objects_server_script():
+    return dedent(
+        '''
+        from mcp.server.fastmcp import FastMCP
+        from typing import Dict, Optional, List, Any
+
+        mcp = FastMCP("Nested Objects Server")
+
+        @mcp.tool()
+        def tool_with_nested_objects(config: Dict[str, Dict[str, Any]]) -> str:
+            """Tool that takes a nested object parameter"""
+            return f"Received config with {len(config)} sections"
+
+        @mcp.tool()
+        def tool_with_optional_nested(config: Optional[Dict[str, Optional[Dict[str, Any]]]] = None) -> str:
+            """Tool that takes an optional nested object parameter with optional inner objects"""
+            if config is None:
+                return "No config provided"
+            sections = sum(1 for v in config.values() if v is not None)
+            return f"Received config with {sections} valid sections"
+
+        mcp.run()
+        '''
+    )
+
+
+@pytest.fixture
 def echo_server_script():
     return dedent(
         '''
@@ -19,7 +84,7 @@ def echo_server_script():
         def echo_tool(text: str) -> str:
             """Echo the input text"""
             return f"Echo: {text}"
-        
+
         mcp.run()
         '''
     )
@@ -69,7 +134,7 @@ def echo_server_optional_script():
             if text is None:
                 return "No input provided"
             return f"Echo: {text}"
-        
+
         mcp.run()
         '''
     )
@@ -135,3 +200,104 @@ def test_optional_sync(echo_server_optional_script):
         assert tools[1].run() == "Echo: empty"
         assert tools[2].name == "echo_tool_union_none"
         assert tools[2].run(text="hello") == "Echo: hello"
+
+
+def test_object_parameters_sync(complex_types_server_script):
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv", args=["run", "python", "-c", complex_types_server_script]
+        ),
+        CrewAIAdapter(),
+    ) as tools:
+        # Test required object parameter
+        tool_with_object = [t for t in tools if t.name == "tool_with_object"][0]
+        assert (
+            tool_with_object.run(config={"key": "value"})
+            == "Received config with 1 keys"
+        )
+
+        # This should raise a validation error since None is not a dict
+        with pytest.raises(ValueError):  # Or appropriate exception from Pydantic
+            tool_with_object.run(config=None)
+
+        # Test optional object parameter
+        tool_with_optional_object = [
+            t for t in tools if t.name == "tool_with_optional_object"
+        ][0]
+        assert (
+            tool_with_optional_object.run(config={"key": "value"})
+            == "Received config with 1 keys"
+        )
+        assert tool_with_optional_object.run() == "No config provided"  # Default None
+        assert (
+            tool_with_optional_object.run(config=None) == "No config provided"
+        )  # Explicit None
+
+
+def test_number_parameters_sync(complex_types_server_script):
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv", args=["run", "python", "-c", complex_types_server_script]
+        ),
+        CrewAIAdapter(),
+    ) as tools:
+        # Test required number parameter
+        tool_with_number = [t for t in tools if t.name == "tool_with_number"][0]
+        assert tool_with_number.run(value=42.5) == "Received value: 42.5"
+
+        # This should raise a validation error since None is not a number
+        with pytest.raises(ValueError):  # Or appropriate exception from Pydantic
+            tool_with_number.run(value=None)
+
+        # Test optional number parameter
+        tool_with_optional_number = [
+            t for t in tools if t.name == "tool_with_optional_number"
+        ][0]
+        assert tool_with_optional_number.run(value=42.5) == "Received value: 42.5"
+        assert tool_with_optional_number.run() == "No value provided"  # Default None
+        assert (
+            tool_with_optional_number.run(value=None) == "No value provided"
+        )  # Explicit None
+
+
+def test_nested_objects_sync(nested_objects_server_script):
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv", args=["run", "python", "-c", nested_objects_server_script]
+        ),
+        CrewAIAdapter(),
+    ) as tools:
+        # Test nested objects parameter
+        tool_with_nested_objects = [
+            t for t in tools if t.name == "tool_with_nested_objects"
+        ][0]
+        assert (
+            tool_with_nested_objects.run(
+                config={"section1": {"key1": "value1"}, "section2": {"key2": "value2"}}
+            )
+            == "Received config with 2 sections"
+        )
+
+        # Test optional nested parameter
+        tool_with_optional_nested = [
+            t for t in tools if t.name == "tool_with_optional_nested"
+        ][0]
+
+        # Test with fully populated nested objects
+        assert (
+            tool_with_optional_nested.run(
+                config={"section1": {"key1": "value1"}, "section2": {"key2": "value2"}}
+            )
+            == "Received config with 2 valid sections"
+        )
+
+        # Test with some null inner objects
+        assert (
+            tool_with_optional_nested.run(
+                config={"section1": {"key1": "value1"}, "section2": None}
+            )
+            == "Received config with 1 valid sections"
+        )
+
+        # Test with null outer object
+        assert tool_with_optional_nested.run() == "No config provided"


### PR DESCRIPTION
Problem:
When an LLM agent using CrewAI adapter makes MCP calls, validation errors occur because optional parameters with None values are being passed to the MCP server. For example, providing only the required "query" parameter results in optional parameters like "filters" and "maxResults" being automatically included with None values, causing the server to reject them with type validation errors.

Root Cause:
The CrewAI adapter was passing all keyword arguments directly to the MCP function call, including those with None values. While the MCP tool schema defines these parameters with anyOf types that include null, the server implementation rejects null values for parameters that should be objects or numbers.

Solution:

Added proper input validation using Pydantic models before sending to MCP Implemented two-step approach:
First validate all inputs against the schema to catch errors in required fields Then filter out None values from optional parameters only Re-raise validation exceptions as ValueError for consistent error handling Test Improvements:

Added new test fixtures:

complex_types_server_script: Testing objects and numbers as parameters nested_objects_server_script: Testing nested object structures with nulls Added comprehensive test cases:

test_object_parameters_sync: Validates required and optional object params test_number_parameters_sync: Validates required and optional number params test_nested_objects_sync: Tests complex nested object structures These tests ensure that:

Required parameters reject None values with appropriate exceptions Optional parameters correctly handle None values (both default and explicit) The adapter properly validates and filters parameters based on schema requirements