### PR TITLE
Fix #46: Filter None values in CrewAI adapter when schema doesn't allow null

### DIFF
--- a/src/mcpadapt/crewai_adapter.py
+++ b/src/mcpadapt/crewai_adapter.py
@@ -63,9 +63,28 @@ class CrewAIAdapter(ToolAdapter):
             args_schema: Type[BaseModel] = ToolInput
 
             def _run(self, *args: Any, **kwargs: Any) -> Any:
-                print("args", args)
-                print("kwargs", kwargs)
-                return func(kwargs).content[0].text  # type: ignore
+                
+                # Filter out None values if the schema doesn't allow null
+                filtered_kwargs: dict[str, Any] = {}
+                schema_properties = mcp_tool.inputSchema.get("properties", {})
+                
+                for key, value in kwargs.items():
+                    if value is None and key in schema_properties:
+                        prop_schema = schema_properties[key]
+                        # Check if the property allows null
+                        # Simple check: if type is a list containing "null" or anyOf includes null
+                        if isinstance(prop_schema.get("type"), list):
+                            if "null" in prop_schema["type"]:
+                                filtered_kwargs[key] = value
+                        elif "anyOf" in prop_schema:
+                            # Check if any option allows null
+                            if any(opt.get("type") == "null" for opt in prop_schema["anyOf"]):
+                                filtered_kwargs[key] = value
+                        # If neither case allows null, skip the None value
+                    else:
+                        filtered_kwargs[key] = value
+                
+                return func(filtered_kwargs).content[0].text  # type: ignore
 
             def _generate_description(self):
                 args_schema = {

--- a/tests/test_crewai_adapter.py
+++ b/tests/test_crewai_adapter.py
@@ -254,3 +254,112 @@ def test_optional_sync(echo_server_optional_script):
         assert tools[1].run() == "Echo: empty"
         assert tools[2].name == "echo_tool_union_none"
         assert tools[2].run(text="hello") == "Echo: hello"
+
+
+@pytest.fixture
+def mcp_server_that_rejects_none_script():
+    return dedent(
+        '''
+        import mcp.types as types
+        from mcp.server.lowlevel import Server
+        from mcp.server.stdio import stdio_server
+        import anyio
+
+        app = Server("mcp-strict-server")
+
+        @app.call_tool()
+        async def call_tool(name: str, arguments: dict | None) -> list[types.TextContent]:
+            if name != "strict_tool":
+                raise ValueError(f"Unknown tool: {name}")
+            
+            # Simulate GitHub MCP server behavior - reject None values
+            if arguments:
+                for key, value in arguments.items():
+                    if value is None:
+                        # MCP servers that reject None values raise an error
+                        raise RuntimeError(f"parameter {key} is not of type string, is <nil>")
+            
+            required = arguments.get("required") if arguments else None
+            optional = arguments.get("optional") if arguments else None  
+            another_optional = arguments.get("another_optional") if arguments else None
+            
+            return [types.TextContent(
+                type="text",
+                text=f"Required: {required}, Optional: {optional}, Another: {another_optional}"
+            )]
+
+        @app.list_tools()
+        async def list_tools() -> list[types.Tool]:
+            return [
+                types.Tool(
+                    name="strict_tool",
+                    description="A tool that expects only string values",
+                    inputSchema={
+                        "type": "object",
+                        "required": ["required"],
+                        "properties": {
+                            "required": {
+                                "type": "string",
+                                "description": "Required parameter",
+                            },
+                            "optional": {
+                                "type": "string", 
+                                "description": "Optional parameter",
+                            },
+                            "another_optional": {
+                                "type": "string",
+                                "description": "Another optional parameter",
+                            }
+                        },
+                    },
+                )
+            ]
+
+        async def arun():
+            async with stdio_server() as streams:
+                await app.run(
+                    streams[0], streams[1], app.create_initialization_options()
+                )
+
+        anyio.run(arun)
+        '''
+    )
+
+
+def test_none_values_filtered_from_kwargs(mcp_server_that_rejects_none_script):
+    """Test that None values are filtered out before being sent to MCP tool.
+    
+    This test reproduces issue #46 where None values in kwargs cause MCP servers
+    to reject the request with 'parameter is not of type string, is <nil>' error.
+    """
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv", args=["run", "python", "-c", mcp_server_that_rejects_none_script]
+        ),
+        CrewAIAdapter(),
+    ) as tools:
+        assert len(tools) == 1
+        tool = tools[0]
+        assert tool.name == "strict_tool"
+        
+        # This should work - only required parameter
+        result = tool.run(required="test")
+        assert "Required: test" in result
+        
+        # This should work - explicit non-None values
+        result = tool.run(required="test", optional="value1", another_optional="value2")
+        assert "Required: test" in result
+        assert "Optional: value1" in result
+        assert "Another: value2" in result
+        
+        # After the fix - CrewAI passes None values but they are filtered out
+        # before being sent to the MCP server if the schema doesn't allow null
+        result = tool.run(required="test", optional=None, another_optional=None)
+        
+        # The fix filters out None values, so the server receives only {"required": "test"}
+        # and returns a successful response with None for the optional parameters
+        assert "Required: test" in result
+        assert "Optional: None" in result
+        assert "Another: None" in result
+        # Most importantly, no error message about "is not of type string, is <nil>"
+        assert "parameter" not in result or "is <nil>" not in result


### PR DESCRIPTION
## Summary
- Fixes #46 by implementing schema-aware filtering of None values in the CrewAI adapter
- Only filters None values when the parameter's schema doesn't explicitly allow null
- Preserves None values when schema allows them (e.g., `type: ["string", "null"]` or `anyOf` with null)

## Problem
When using CrewAI with MCP servers like the GitHub MCP server, passing None values for optional parameters causes errors:
```
parameter head is not of type string, is <nil>
```

## Solution
The fix inspects the tool's input schema before calling the MCP tool:
- If a parameter's schema allows null values, the None is preserved
- If the schema only allows non-null types (e.g., just "string"), the None value is filtered out
- This ensures compatibility with strict MCP servers while maintaining flexibility for servers that accept null

## Test plan
- [x] Added test case that reproduces the issue with a strict MCP server
- [x] Test verifies None values are filtered when schema doesn't allow null
- [x] All existing tests pass
- [x] Linting and type checking pass