### PR TITLE
Enable Optional inputs in CrewAI adapter

### DIFF
--- a/src/echo.py
+++ b/src/echo.py
@@ -10,16 +10,20 @@ mcp = FastMCP("Echo Server")
 
 
 @mcp.tool()
-def echo_tool(text: str = Field(description="The text to echo")) -> str:
+def echo_tool(
+    id: int | float | None,
+    text: str = Field(description="The text to echo"),
+) -> str:
     """Echo the input text
 
     Args:
+        id (int|float|None): (Optional) Id
         text (str): The text to echo
 
     Returns:
         str: The echoed text
     """
-    return text
+    return f"echo_tool({id},{text})"
 
 
 @mcp.resource("echo://static")


### PR DESCRIPTION
The current CrewAI adapter implementation requires passing all the values for arguments that don't have a default value, but fails when the MCP tool provides an optional argument. For example, the following code:

```python
@mcp.tool()
def echo_tool(
    id: int | float | None,
    text: str = Field(description="The text to echo"),
) -> str:
    pass
```

Results in the following error

```bash
starting echo server
[06/11/25 18:23:31] INFO     Processing request of type ListToolsRequest                                                                                                                                                                                                                                      server.py:551
                    INFO     Processing request of type ListToolsRequest                                                                                                                                                                                                                                      server.py:551
[CrewAIMCPTool(name='echo_tool', description="Tool Name: echo_tool\nTool Arguments: {'properties': {'id': {'anyOf': [{'type': 'integer'}, {'type': 'number'}, {'type': 'null'}], 'description': '', 'enum': None, 'items': None, 'properties': {}, 'title': 'Id'}, 'text': {'anyOf': [], 'description': 'The text to echo', 'enum': None, 'items': None, 'properties': {}, 'title': 'Text', 'type': 'string'}}, 'required': ['id', 'text'], 'title': 'echo_toolArguments', 'type': 'object'}\nTool Description: Echo the input text\n\n    Args:\n        id (int|float|None): (Optional) Id\n        text (str): The text to echo\n\n    Returns:\n        str: The echoed text\n    ", args_schema=<class 'mcpadapt.utils.modeling.echo_toolArguments'>, description_updated=False, cache_function=<function BaseTool.<lambda> at 0x108f2d5a0>, result_as_answer=False)]
Using Tool: echo_tool
                    INFO     Processing request of type CallToolRequest                                                                                                                                                                                                                                       server.py:551
Error executing tool echo_tool: 1 validation error for echo_toolArguments
id
  Field required [type=missing, input_value={'text': 'hello'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/missing
```

When the tool doesn't provide an `id` value, like `tools[0].run(text="hello")`

This change modifies the way to populate `filtered_kwargs` variable utilizing the `schema_properties` values instead of the `kwargs`