### PR TITLE
Allow Nullable Required Model fields

### DIFF
--- a/src/mcpadapt/utils/modeling.py
+++ b/src/mcpadapt/utils/modeling.py
@@ -145,7 +145,7 @@ def create_model_from_json_schema(
             default = field_schema.get("default")
             is_required = field_name in required and default is None
 
-            if is_nullable and not is_required:
+            if is_nullable or not is_required:
                 field_type = Optional[field_type]  # type: ignore
 
             return field_type, ... if is_required else default


### PR DESCRIPTION
Considering the following scenario:
```python
@mcp.tool()
def echo_tool(id: int|None, text: str = Field(description="The text to echo")) -> str:
...
```
Which results in this input schema
```python
{'properties': {'id': {'anyOf': [{'type': 'integer'}, {'type': 'null'}], 'title': 'Id'}, 'text': {'description': 'The text to echo', 'title': 'Text', 'type': 'string'}}, 'required': ['id', 'text'], 'title': 'echo_toolArguments', 'type': 'object'}
```
Where the `id` field is required but nullable at the same time.

For this scenario, the field needs to be interpreted as Python Optional field. This PR allows that case.