### PR TITLE
Fix link in smolagents guide

### DIFF
--- a/docs/guide/smolagents.md
+++ b/docs/guide/smolagents.md
@@ -112,7 +112,7 @@ This approach achieves the same result but uses MCPAdapt directly with its smola
 
 ## Full Working Code Example
 
-You a fully working script of this example [here](https://github.com/grll/mcpadapt/blob/main/examples/smolagents_pubmed.py)
+You can find a fully working script of this example [here](https://github.com/grll/mcpadapt/blob/main/examples/smolagents_pubmed.py)
 
 
 


### PR DESCRIPTION
## Summary
- fix wording in docs/guide/smolagents.md and link to working example script

## Testing
- `make format`
- `make lint`
- `make mypy` *(fails: No module named 'mcp', etc.)*
- `make tests` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_6853d6381868832da514cc8a94c08d1a