### PR TITLE
Fix typos in MCPAdapt class docstring

### DIFF
--- a/src/mcpadapt/core.py
+++ b/src/mcpadapt/core.py
@@ -139,7 +139,7 @@ class MCPAdapt:
     If running asynchronously, it will use the async context manager and return async
     tools.
 
-    Dependening on what your Agent framework supports choose the approriate method. If
+    Depending on what your Agent framework supports choose the appropriate method. If
     async is supported it is recommended.
 
     Important Note: adapters need to implement the async_adapt method to support async


### PR DESCRIPTION
## Summary
- fix small typos in `MCPAdapt` class docstring

## Testing
- `make lint`
- `make tests` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_6853d621fc30832dbab176c6be7fc919