### PR TITLE
Remove duplicate json_type_mapping

### DIFF
--- a/src/mcpadapt/utils/modeling.py
+++ b/src/mcpadapt/utils/modeling.py
@@ -12,15 +12,6 @@ json_type_mapping: dict[str, Type] = {
     "array": list,
 }
 
-json_type_mapping = {
-    "string": str,
-    "number": float,
-    "integer": int,
-    "boolean": bool,
-    "object": dict,
-    "array": list,
-}
-
 
 def resolve_refs_and_remove_defs(json_obj):
     # Extract $defs


### PR DESCRIPTION
## Summary
- delete repeated `json_type_mapping` definition in modeling utils

## Testing
- `pytest -q tests/utils/test_modeling.py`

------
https://chatgpt.com/codex/tasks/task_e_6853d62e8bf0832d9d3be920ec408517