### PR TITLE
Update sync SSE test

### DIFF
--- a/tests/test_langchain_adapter.py
+++ b/tests/test_langchain_adapter.py
@@ -136,6 +136,8 @@ def test_basic_sync_sse(echo_sse_server):
         LangChainAdapter(),
     ) as tools:
         assert len(tools) == 1
+        assert tools[0].name == "echo_tool"
+        assert tools[0].invoke("hello") == "Echo: hello"
 
 
 def test_json_schema_array_type_handling(json_schema_array_type_server_script):


### PR DESCRIPTION
## Summary
- expand test coverage for LangChainAdapter sync SSE mode

## Testing
- `pytest -q` *(fails: TimeoutError, network unreachable for ipywidgets/notebook)*

------
https://chatgpt.com/codex/tasks/task_e_6853d649a668832dad4a3d875bf8a79a