### PR TITLE
feat: Add structured output support to SmolAgentsAdapter (#62)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "Guillaume Raille", email = "guillaume.raille@gmail.com" }]
 dependencies = [
-    "mcp>=1.9.0",
+    "mcp>=1.10.1",
     "jsonref>=1.1.0",
     "python-dotenv>=1.0.1",
     "pydantic>=2.10.6",

--- a/src/mcpadapt/smolagents_adapter.py
+++ b/src/mcpadapt/smolagents_adapter.py
@@ -3,11 +3,62 @@
 SmolAgents do not support async tools, so this adapter will only work with the sync
 context manager.
 
+Features:
+- Converts MCP tools to SmolAgents tools
+- Supports outputSchema for structured output (MCP spec 2025-06-18+)
+- Simple output type detection: structured (object) vs plain text (string)
+- Handles both structured data and text content
+- Validates output against schema (with warnings, non-strict)
+- Backwards compatible with tools without outputSchema
+
 Example Usage:
->>> with MCPAdapt(StdioServerParameters(command="uv", args=["run", "src/echo.py"]), SmolAgentAdapter()) as tools:
+>>> with MCPAdapt(StdioServerParameters(command="uv", args=["run", "src/echo.py"]), SmolAgentsAdapter()) as tools:
 >>>     print(tools)
+
+>>> # Enable structured output features
+>>> with MCPAdapt(server_params, SmolAgentsAdapter(structured_output=True)) as tools:
+>>>     # Tools now support outputSchema, structuredContent, JSON parsing, etc.
+
+Structured Output Architecture:
+
+The adapter uses a two-level parameter system for clean separation of concerns:
+
+1. `structured_output` (Adapter-level, user-facing):
+   - Set by user when creating SmolAgentsAdapter(structured_output=True/False)
+   - Controls global behavior for all tools created by this adapter instance
+   - Determines whether to process outputSchema from MCP tools
+   - Default: False (for backwards compatibility)
+
+2. `use_structured_features` (Tool-level, internal):
+   - Passed to each individual MCPAdaptTool during creation
+   - Always equals the adapter's structured_output value
+   - Controls how each tool processes its output (structuredContent, JSON parsing, etc.)
+   - Allows each tool to operate independently without referencing parent adapter
+
+Flow: User Intent → Adapter Config → Schema Processing → Tool Creation → Tool Behavior
+      structured_output=True → self.structured_output → outputSchema extraction → use_structured_features=True → Enhanced processing
+
+Output Schema Support:
+The adapter supports MCP outputSchema with a simplified approach:
+- If outputSchema is provided → output_type = "object" (structured data expected)
+- If no outputSchema → output_type = "string" (plain text expected)
+
+When an MCP tool provides an outputSchema, the adapter will:
+1. Use structuredContent if available from the MCP tool response
+2. Parse JSON from text content if structured data is expected but not provided
+3. Validate output against the schema (warnings only, not strict)
+4. Fall back to returning text as-is for backwards compatibility
+
+Backwards Compatibility:
+- structured_output=False (default): Uses original simple text-only behavior
+- structured_output=True: Enables enhanced features while maintaining fallback compatibility
+- No breaking changes to existing code
+
+This avoids making assumptions about which specific JSON Schema types MCP officially
+supports, focusing on the fundamental distinction between structured vs. unstructured output.
 """
 
+import json
 import logging
 import keyword
 import re
@@ -44,6 +95,46 @@ def _sanitize_function_name(name):
     return name
 
 
+def _validate_output_against_schema(
+    output: Any,
+    schema: dict[str, Any] | None,
+    tool_name: str,
+    strict: bool = False
+) -> Any:
+    """
+    Optionally validate output against schema.
+
+    Since we simplified to only "object" vs "string" output types, this just does
+    basic validation that structured output was provided when a schema exists.
+
+    Args:
+        output: The output to validate
+        schema: The JSON schema to validate against
+        tool_name: Tool name for error messages
+        strict: If True, raise exception on validation failure; if False, just log warning
+
+    Returns:
+        The original output (unchanged)
+
+    Raises:
+        ValueError: If strict=True and validation fails
+    """
+    if not schema:
+        return output
+
+    # Basic check: if there's a schema, we expect some kind of structured data
+    # (not just a plain string, unless the schema specifically expects a string)
+    schema_type = schema.get("type")
+    if schema_type != "string" and isinstance(output, str):
+        error_msg = f"tool {tool_name} has outputSchema but returned plain text instead of structured data"
+        if strict:
+            raise ValueError(error_msg)
+        else:
+            logger.warning(error_msg)
+
+    return output
+
+
 class SmolAgentsAdapter(ToolAdapter):
     """Adapter for the `smolagents` framework.
 
@@ -54,6 +145,17 @@ class SmolAgentsAdapter(ToolAdapter):
     dashes, the tool name will be sanitized to become a valid python function name.
 
     """
+
+    def __init__(self, structured_output: bool = False):
+        """Initialize the SmolAgentsAdapter.
+
+        Args:
+            structured_output: If True, enable structured output features including
+                              outputSchema support and structured content handling.
+                              If False, use the original simple behavior.
+                              Defaults to False for backwards compatibility.
+        """
+        self.structured_output = structured_output
 
     def adapt(
         self,
@@ -70,47 +172,6 @@ class SmolAgentsAdapter(ToolAdapter):
             A SmolAgents tool.
         """
 
-        class MCPAdaptTool(smolagents.Tool):
-            def __init__(
-                self,
-                name: str,
-                description: str,
-                inputs: dict[str, dict[str, str]],
-                output_type: str,
-            ):
-                self.name = _sanitize_function_name(name)
-                self.description = description
-                self.inputs = inputs
-                self.output_type = output_type
-                self.is_initialized = True
-                self.skip_forward_signature_validation = True
-
-            def forward(self, *args, **kwargs) -> str:
-                if len(args) > 0:
-                    if len(args) == 1 and isinstance(args[0], dict) and not kwargs:
-                        mcp_output = func(args[0])
-                    else:
-                        raise ValueError(
-                            f"tool {self.name} does not support multiple positional arguments or combined positional and keyword arguments"
-                        )
-                else:
-                    mcp_output = func(kwargs)
-
-                if len(mcp_output.content) == 0:
-                    raise ValueError(f"tool {self.name} returned an empty content")
-
-                if len(mcp_output.content) > 1:
-                    logger.warning(
-                        f"tool {self.name} returned multiple content, using the first one"
-                    )
-
-                if not isinstance(mcp_output.content[0], mcp.types.TextContent):
-                    raise ValueError(
-                        f"tool {self.name} returned a non-text content: `{type(mcp_output.content[0])}`"
-                    )
-
-                return mcp_output.content[0].text  # type: ignore
-
         # make sure jsonref are resolved
         input_schema = {
             k: v
@@ -125,11 +186,104 @@ class SmolAgentsAdapter(ToolAdapter):
             if "type" not in v:
                 input_schema["properties"][k]["type"] = "string"
 
+        # Extract and resolve outputSchema if present (only when structured_output=True)
+        output_schema = None
+        if self.structured_output and hasattr(mcp_tool, 'outputSchema') and mcp_tool.outputSchema:
+            try:
+                output_schema = jsonref.replace_refs(mcp_tool.outputSchema)
+            except Exception as e:
+                logger.warning(f"Failed to resolve outputSchema for tool {mcp_tool.name}: {e}")
+                output_schema = mcp_tool.outputSchema  # Use unresolved schema as fallback
+
+        # Determine output_type based on mode and schema
+        if self.structured_output and output_schema:
+            output_type = "object"  # Structured data expected
+        else:
+            output_type = "string"  # Plain text expected
+
+        class MCPAdaptTool(smolagents.Tool):
+            def __init__(
+                self,
+                name: str,
+                description: str,
+                inputs: dict[str, dict[str, str]],
+                output_type: str,
+                output_schema: dict[str, Any] | None = None,
+                use_structured_features: bool = False,
+            ):
+                self.name = _sanitize_function_name(name)
+                self.description = description
+                self.inputs = inputs
+                self.output_type = output_type
+                self.output_schema = output_schema
+                self.use_structured_features = use_structured_features
+                self.is_initialized = True
+                self.skip_forward_signature_validation = True
+
+            def forward(self, *args, **kwargs) -> Any:
+                if len(args) > 0:
+                    if len(args) == 1 and isinstance(args[0], dict) and not kwargs:
+                        mcp_output = func(args[0])
+                    else:
+                        raise ValueError(
+                            f"tool {self.name} does not support multiple positional arguments or combined positional and keyword arguments"
+                        )
+                else:
+                    mcp_output = func(kwargs)
+
+                # Early exit for empty content
+                if not mcp_output.content:
+                    raise ValueError(f"tool {self.name} returned an empty content")
+
+                # Handle structured features if enabled
+                if self.use_structured_features:
+                    # Prioritize structuredContent if available
+                    if hasattr(mcp_output, 'structuredContent') and mcp_output.structuredContent is not None:
+                        return _validate_output_against_schema(
+                            mcp_output.structuredContent, self.output_schema, self.name, strict=False
+                        )
+
+                # Handle multiple content warning (unified for both modes)
+                if len(mcp_output.content) > 1:
+                    warning_msg = (
+                        f"tool {self.name} returned multiple content items but no structuredContent. Using the first content item."
+                        if self.use_structured_features
+                        else f"tool {self.name} returned multiple content, using the first one"
+                    )
+                    logger.warning(warning_msg)
+
+                # Get the first content item
+                content_item = mcp_output.content[0]
+                if not isinstance(content_item, mcp.types.TextContent):
+                    raise ValueError(
+                        f"tool {self.name} returned a non-text content: `{type(content_item)}`"
+                    )
+
+                text_content = content_item.text  # type: ignore
+
+                # Apply structured processing if enabled and expecting structured output
+                if self.use_structured_features and self.output_type == "object" and text_content:
+                    try:
+                        parsed_data = json.loads(text_content)
+                        return _validate_output_against_schema(
+                            parsed_data, self.output_schema, self.name, strict=False
+                        )
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            f"tool {self.name} expected structured output but got unparseable text: {text_content[:100]}..."
+                        )
+                        # Fall through to return text as-is for backwards compatibility
+
+                # Return simple text content (works for both modes)
+                return text_content
+
         tool = MCPAdaptTool(
             name=mcp_tool.name,
             description=mcp_tool.description or "",
             inputs=input_schema["properties"],
-            output_type="string",
+            output_type=output_type,
+            output_schema=output_schema,
+            use_structured_features=self.structured_output,
         )
 
         return tool

--- a/tests/test_smolagents_adapter_structured_output.py
+++ b/tests/test_smolagents_adapter_structured_output.py
@@ -1,0 +1,199 @@
+from textwrap import dedent
+import logging
+
+import pytest
+from mcp import StdioServerParameters
+
+from mcpadapt.core import MCPAdapt
+from mcpadapt.smolagents_adapter import SmolAgentsAdapter
+
+
+def test_weather_sync():
+    weather_server_script = dedent(
+        """
+        from mcp.server.fastmcp import FastMCP
+        from typing import Any
+
+        mcp = FastMCP("Weather Server")
+
+        @mcp.tool()
+        def weather_tool(location: str) -> dict[str, Any]:
+            '''Get the weather for a given location'''
+            return {
+                "weather": "sunny",
+                "temperature": 70,
+                "humidity": 50,
+                "wind_speed": 10,
+            }
+
+        mcp.run()
+        """
+    )
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv", args=["run", "python", "-c", weather_server_script]
+        ),
+        SmolAgentsAdapter(structured_output=True),
+    ) as tools:
+        assert len(tools) == 1
+        tool = tools[0]
+        assert tool.name == "weather_tool"
+
+        # Check tool properties and the auto-generated output schema
+        assert tool.output_type == "object"
+        assert tool.output_schema is not None
+
+        # Verify the schema's structure and types
+        assert tool.output_schema.get("type") == "object"
+        assert tool.output_schema.get("additionalProperties") is True
+        assert isinstance(tool.output_schema.get("title"), str)
+
+        # Verify the tool call works as expected
+        assert tool(location="New York") == {
+            "weather": "sunny",
+            "temperature": 70,
+            "humidity": 50,
+            "wind_speed": 10,
+        }
+
+
+def test_validation_warning_for_unparseable_json(caplog):
+    """Tests that a warning is logged for unparseable JSON when a structured object is expected."""
+    server_script = dedent(
+        '''
+        from mcp.server.fastmcp import FastMCP
+        from typing import Any
+
+        mcp = FastMCP("Validation Server")
+
+        @mcp.tool()
+        def returns_unparseable_text() -> dict[str, Any]:
+            """
+            This tool's type hint suggests a dict, which implies a structured
+            output is expected. However, it returns a non-JSON string.
+            FastMCP's runtime validation should catch this and return an error.
+            """
+            # Note: We return a string from a function hinted to return a dict.
+            # This is bad practice, but tests client-side robustness.
+            return "this is not a valid json object" # type: ignore
+
+        mcp.run()
+        '''
+    )
+
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv", args=["run", "python", "-c", server_script]
+        ),
+        SmolAgentsAdapter(structured_output=True),
+    ) as tools:
+        assert len(tools) == 1
+        tool = tools[0]
+        assert tool.name == "returns_unparseable_text"
+        assert tool.output_type == "object"
+
+        # The tool call returns an error string from FastMCP's validation.
+        # We check that it's a string containing "error" to keep the test robust.
+        result = tool()
+        assert isinstance(result, str)
+        assert "error" in result.lower()
+
+        # We also check that our adapter logged a warning.
+        # We check for the log level and the key concept ("unparseable"),
+        # making the test robust against future changes to the log message.
+        assert any(
+            r.levelno == logging.WARNING and "unparseable" in r.message.lower()
+            for r in caplog.records
+        )
+
+
+def test_list_cities_tool():
+    """Ensure list outputs are wrapped into a dict and schema reflects this."""
+    list_cities_server_script = dedent(
+        '''
+        from mcp.server.fastmcp import FastMCP
+        from typing import Any
+
+        mcp = FastMCP("Cities Server")
+
+        # Lists are wrapped automatically by FastMCP as {"result": list}
+        @mcp.tool()
+        def list_cities() -> list[str]:
+            """Get a list of cities"""
+            return ["London", "Paris", "Tokyo"]
+
+        mcp.run()
+        '''
+    )
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv", args=["run", "python", "-c", list_cities_server_script]
+        ),
+        SmolAgentsAdapter(structured_output=True),
+    ) as tools:
+        assert len(tools) == 1
+        tool = tools[0]
+        assert tool.name == "list_cities"
+
+        # Schema checks
+        assert tool.output_type == "object"
+        schema = tool.output_schema
+        assert isinstance(schema, dict)
+        assert schema.get("type") == "object"
+        properties = schema.get("properties")
+        assert isinstance(properties, dict)
+        assert "result" in properties
+        # The result property should describe an array of strings
+        assert properties["result"].get("type") == "array"
+        items = properties["result"].get("items", {})
+        # Items type may not always be present, but if it is, should be string
+        if isinstance(items, dict) and "type" in items:
+            assert items["type"] == "string"
+
+        # Call the tool and verify the wrapper structure
+        result = tool()
+        assert isinstance(result, dict)
+        assert result["result"] == ["London", "Paris", "Tokyo"]
+
+        # Check the actual city names returned
+        cities = result["result"]
+        assert "London" in cities
+        assert "Paris" in cities
+        assert "Tokyo" in cities
+
+
+def test_simple_text_tool():
+    """Tests structured output with fallback to string output."""
+    server_script = dedent(
+        """
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("Simple Server")
+
+        @mcp.tool()
+        def hello_world():
+            '''Returns a simple greeting.'''
+            return "hello world"
+
+        mcp.run()
+        """
+    )
+
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv", args=["run", "python", "-c", server_script]
+        ),
+        SmolAgentsAdapter(structured_output=True),
+    ) as tools:
+        assert len(tools) == 1
+        tool = tools[0]
+        assert tool.name == "hello_world"
+
+        # Verify that a simple string output results in "string" type and no schema
+        assert tool.output_type == "string"
+        assert tool.output_schema is None
+
+        # Call the tool and check the output
+        result = tool()
+        assert result == "hello world"
+


### PR DESCRIPTION
## Summary

This PR implements structured output support for the SmolAgentsAdapter as described in issue #62. The adapter now handles MCP tools with `outputSchema` definitions.

## Motivation

The latest [MCP specifications (2025-06-18+)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema) include support for `outputSchema`, which enables tools to return structured data with defined schemas.
 
It would be great to take advantage of the structured output capabilities that MCP now offers. This enhancement would allow smolagents to use tools that return complex data structures, JSON objects, and other structured formats.

## Implementation Details

I tried to add following:

- **Structured Output Detection**: Automatically detects when MCP tools provide `outputSchema` and sets `output_type="object"` accordingly
- **Enhanced Content Processing**: Prioritizes `structuredContent` from MCP responses when available
- **JSON Parsing**: Attempts to parse JSON from text content when structured output is expected
- **Schema Validation**: Validates output against provided schema (with warnings, non-strict mode)
- **Backwards Compatibility**: Maintains existing behavior when `structured_output=False` (default)

I implemented a two-level parameter system:
- `structured_output` (adapter-level): User-facing flag to enable/disable structured features
- `use_structured_features` (tool-level): Internal flag controlling individual tool behavior

### Usage
```python
# Original behavior (backwards compatible)
adapter = SmolAgentsAdapter()

# New structured output features
adapter = SmolAgentsAdapter(structured_output=True)
```

## Testing

I added comprehensive tests in `tests/test_smolagents_adapter_structured_output.py` covering:
- ✅ Weather tool with structured JSON output
- ✅ Schema validation with warnings for invalid outputs  
- ✅ List output handling
- ✅ Fallback behavior for unparseable JSON
- ✅ Backwards compatibility verification

All existing tests continue to pass, ensuring no breaking changes.

## Demo

I prepared a PR for smolagents that is using the structured output feature of SmolAgentsAdaper.
With our changes smolagents needs only **one** step to respond with an answer:


```
╭──────────────────────────────────────────────── New run ─────────────────────────────────────────────────╮
│                                                                                                          │
│ What is the temperature in Toronto?                                                                      │
│                                                                                                          │
╰─ LiteLLMModel - openai/gpt-4.1 ──────────────────────────────────────────────────────────────────────────╯
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Step 1 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ─ Executing parsed code: ─────────────────────────────────────────────────────────────────────────────────
  weather_info = weather_tool(location="Toronto")
  temperature = weather_info["temperature"]
  final_answer(f"The temperature in Toronto is {temperature}°F.")
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────
[07/04/25 11:25:40] INFO     Processing request of type CallToolRequest                        server.py:619
Final answer: The temperature in Toronto is 70°F.
[Step 1: Duration 1.99 seconds| Input tokens: 2,328 | Output tokens: 83]
```

In this example smolgents is using an extended system prompt showing the LLM the output schema of the tool.

```
...
Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools, behaving like regular python functions:
<code>
def weather_tool(location: string) -> object:
    """Get the weather for a given location
    
    Important:
        If this tool is used in your code, you must use the JSON schema below – describing the output of the tool – to access values of the tool output!

    Args:
        location: The location to get the weather for

    Returns:
        object: The output object is a dictionary conforming to the following JSON schema:
            {
                "properties": {
                    "humidity": {
                        "description": "The humidity in percentage",
                        "title": "Humidity",
                        "type": "integer"
                    },
                    "temperature": {
                        "description": "The temperature in Celsius",
                        "title": "Temperature",
                        "type": "integer"
                    },
                    "weather": {
                        "description": "The weather condition",
                        "title": "Weather",
                        "type": "string"
                    },
                    "wind_speed": {
                        "description": "The wind speed in miles per hour",
                        "title": "Wind Speed",
                        "type": "integer"
                    }
                },
                "required": [
                    "weather",
                    "temperature",
                    "humidity",
                    "wind_speed"
                ],
                "title": "Weather",
                "type": "object"
            }
    """
</code>
...
```


## Backwards Compatibility

This implementation maintains 100% backwards compatibility:
- Default behavior unchanged (`structured_output=False`)
- Existing code continues to work without modification
- New features are opt-in only

## Request for Feedback

This is my first contribution to mcpadapt, so I welcome any suggestions for improvements or alternative approaches!

Fixes #62