### PR TITLE
[MINOR] Handle multiple responses are returned from MCP

### DIFF
--- a/src/mcpadapt/crewai_adapter.py
+++ b/src/mcpadapt/crewai_adapter.py
@@ -86,7 +86,13 @@ class CrewAIAdapter(ToolAdapter):
                     else:
                         filtered_kwargs[key] = value
 
-                return func(filtered_kwargs).content[0].text  # type: ignore
+                result = func(filtered_kwargs)
+                texts = [
+                    content.text
+                    for content in result.content
+                    if hasattr(content, "text")
+                ]
+                return texts
 
             def _generate_description(self):
                 args_schema = {

--- a/src/mcpadapt/crewai_adapter.py
+++ b/src/mcpadapt/crewai_adapter.py
@@ -87,12 +87,17 @@ class CrewAIAdapter(ToolAdapter):
                         filtered_kwargs[key] = value
 
                 result = func(filtered_kwargs)
-                texts = [
-                    content.text
-                    for content in result.content
-                    if hasattr(content, "text")
-                ]
-                return texts
+                return (
+                    result.content[0].text
+                    if len(result.content) == 1
+                    else str(
+                        [
+                            content.text
+                            for content in result.content
+                            if hasattr(content, "text")
+                        ]
+                    )
+                )
 
             def _generate_description(self):
                 args_schema = {

--- a/tests/test_crewai_adapter.py
+++ b/tests/test_crewai_adapter.py
@@ -178,7 +178,7 @@ def test_basic_sync(echo_server_script):
     ) as tools:
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
-        assert tools[0].run(text="hello") == "Echo: hello"
+        assert tools[0].run(text="hello") == ["Echo: hello"]
 
 
 # Fails if enums, unions, or pydantic classes are not included in the
@@ -235,7 +235,7 @@ def test_basic_sync_sse(echo_sse_server):
     ) as tools:
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
-        assert tools[0].run(text="hello") == "Echo: hello"
+        assert tools[0].run(text="hello") == ["Echo: hello"]
 
 
 def test_optional_sync(echo_server_optional_script):
@@ -247,13 +247,13 @@ def test_optional_sync(echo_server_optional_script):
     ) as tools:
         assert len(tools) == 3
         assert tools[0].name == "echo_tool_optional"
-        assert tools[0].run(text="hello") == "Echo: hello"
+        assert tools[0].run(text="hello") == ["Echo: hello"]
         assert tools[0].run() == "No input provided"
         assert tools[1].name == "echo_tool_default_value"
-        assert tools[1].run(text="hello") == "Echo: hello"
+        assert tools[1].run(text="hello") == ["Echo: hello"]
         assert tools[1].run() == "Echo: empty"
         assert tools[2].name == "echo_tool_union_none"
-        assert tools[2].run(text="hello") == "Echo: hello"
+        assert tools[2].run(text="hello") == ["Echo: hello"]
 
 
 @pytest.fixture
@@ -345,13 +345,13 @@ def test_none_values_filtered_from_kwargs(mcp_server_that_rejects_none_script):
 
         # This should work - only required parameter
         result = tool.run(required="test")
-        assert "Required: test" in result
+        assert "Required: test" in result[0]
 
         # This should work - explicit non-None values
         result = tool.run(required="test", optional="value1", another_optional="value2")
-        assert "Required: test" in result
-        assert "Optional: value1" in result
-        assert "Another: value2" in result
+        assert "Required: test" in result[0]
+        assert "Optional: value1" in result[0]
+        assert "Another: value2" in result[0]
 
         # After the fix - CrewAI passes None values but they are filtered out
         # before being sent to the MCP server if the schema doesn't allow null
@@ -359,8 +359,8 @@ def test_none_values_filtered_from_kwargs(mcp_server_that_rejects_none_script):
 
         # The fix filters out None values, so the server receives only {"required": "test"}
         # and returns a successful response with None for the optional parameters
-        assert "Required: test" in result
-        assert "Optional: None" in result
-        assert "Another: None" in result
+        assert "Required: test" in result[0]
+        assert "Optional: None" in result[0]
+        assert "Another: None" in result[0]
         # Most importantly, no error message about "is not of type string, is <nil>"
-        assert "parameter" not in result or "is <nil>" not in result
+        assert "parameter" not in result[0] or "is <nil>" not in result[0]

--- a/tests/test_crewai_adapter.py
+++ b/tests/test_crewai_adapter.py
@@ -178,7 +178,7 @@ def test_basic_sync(echo_server_script):
     ) as tools:
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
-        assert tools[0].run(text="hello") == ["Echo: hello"]
+        assert tools[0].run(text="hello") == "Echo: hello"
 
 
 # Fails if enums, unions, or pydantic classes are not included in the
@@ -235,7 +235,7 @@ def test_basic_sync_sse(echo_sse_server):
     ) as tools:
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
-        assert tools[0].run(text="hello") == ["Echo: hello"]
+        assert tools[0].run(text="hello") == "Echo: hello"
 
 
 def test_optional_sync(echo_server_optional_script):
@@ -247,13 +247,13 @@ def test_optional_sync(echo_server_optional_script):
     ) as tools:
         assert len(tools) == 3
         assert tools[0].name == "echo_tool_optional"
-        assert tools[0].run(text="hello") == ["Echo: hello"]
+        assert tools[0].run(text="hello") == "Echo: hello"
         assert tools[0].run() == "No input provided"
         assert tools[1].name == "echo_tool_default_value"
-        assert tools[1].run(text="hello") == ["Echo: hello"]
+        assert tools[1].run(text="hello") == "Echo: hello"
         assert tools[1].run() == "Echo: empty"
         assert tools[2].name == "echo_tool_union_none"
-        assert tools[2].run(text="hello") == ["Echo: hello"]
+        assert tools[2].run(text="hello") == "Echo: hello"
 
 
 @pytest.fixture
@@ -345,13 +345,13 @@ def test_none_values_filtered_from_kwargs(mcp_server_that_rejects_none_script):
 
         # This should work - only required parameter
         result = tool.run(required="test")
-        assert "Required: test" in result[0]
+        assert "Required: test" in result
 
         # This should work - explicit non-None values
         result = tool.run(required="test", optional="value1", another_optional="value2")
-        assert "Required: test" in result[0]
-        assert "Optional: value1" in result[0]
-        assert "Another: value2" in result[0]
+        assert "Required: test" in result
+        assert "Optional: value1" in result
+        assert "Another: value2" in result
 
         # After the fix - CrewAI passes None values but they are filtered out
         # before being sent to the MCP server if the schema doesn't allow null
@@ -359,8 +359,8 @@ def test_none_values_filtered_from_kwargs(mcp_server_that_rejects_none_script):
 
         # The fix filters out None values, so the server receives only {"required": "test"}
         # and returns a successful response with None for the optional parameters
-        assert "Required: test" in result[0]
-        assert "Optional: None" in result[0]
-        assert "Another: None" in result[0]
+        assert "Required: test" in result
+        assert "Optional: None" in result
+        assert "Another: None" in result
         # Most importantly, no error message about "is not of type string, is <nil>"
-        assert "parameter" not in result[0] or "is <nil>" not in result[0]
+        assert "parameter" not in result or "is <nil>" not in result

--- a/tests/test_crewai_adapter.py
+++ b/tests/test_crewai_adapter.py
@@ -364,3 +364,133 @@ def test_none_values_filtered_from_kwargs(mcp_server_that_rejects_none_script):
         assert "Another: None" in result
         # Most importantly, no error message about "is not of type string, is <nil>"
         assert "parameter" not in result or "is <nil>" not in result
+
+
+@pytest.fixture
+def single_content_server_script():
+    return dedent(
+        """
+        import mcp.types as types
+        from mcp.server.lowlevel import Server
+        from mcp.server.stdio import stdio_server
+        import anyio
+
+        app = Server("single-content-server")
+
+        @app.call_tool()
+        async def call_tool(name: str, arguments: dict | None) -> list[types.TextContent]:
+            if name != "single_content_tool":
+                raise ValueError(f"Unknown tool: {name}")
+            
+            # Return single content response
+            return [types.TextContent(
+                type="text", 
+                text="Single response"
+            )]
+
+        @app.list_tools()
+        async def list_tools() -> list[types.Tool]:
+            return [
+                types.Tool(
+                    name="single_content_tool",
+                    description="A tool that returns single content",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {},
+                    },
+                )
+            ]
+
+        async def arun():
+            async with stdio_server() as streams:
+                await app.run(
+                    streams[0], streams[1], app.create_initialization_options()
+                )
+
+        anyio.run(arun)
+        """
+    )
+
+
+@pytest.fixture
+def multiple_content_server_script():
+    return dedent(
+        """
+        import mcp.types as types
+        from mcp.server.lowlevel import Server
+        from mcp.server.stdio import stdio_server
+        import anyio
+
+        app = Server("multiple-content-server")
+
+        @app.call_tool()
+        async def call_tool(name: str, arguments: dict | None) -> list[types.TextContent]:
+            if name != "multiple_content_tool":
+                raise ValueError(f"Unknown tool: {name}")
+            
+            # Return multiple content responses
+            return [
+                types.TextContent(type="text", text="First response"),
+                types.TextContent(type="text", text="Second response"),
+                types.TextContent(type="text", text="Third response")
+            ]
+
+        @app.list_tools()
+        async def list_tools() -> list[types.Tool]:
+            return [
+                types.Tool(
+                    name="multiple_content_tool",
+                    description="A tool that returns multiple content items",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {},
+                    },
+                )
+            ]
+
+        async def arun():
+            async with stdio_server() as streams:
+                await app.run(
+                    streams[0], streams[1], app.create_initialization_options()
+                )
+
+        anyio.run(arun)
+        """
+    )
+
+
+def test_single_content_response_handling(single_content_server_script):
+    """Test that single content responses return just the text content."""
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv",
+            args=["run", "python", "-c", single_content_server_script],
+        ),
+        CrewAIAdapter(),
+    ) as tools:
+        assert len(tools) == 1
+        tool = tools[0]
+        assert tool.name == "single_content_tool"
+
+        result = tool.run()
+        # Should return the single text content directly, not as a list
+        assert result == "Single response"
+
+
+def test_multiple_content_response_handling(multiple_content_server_script):
+    """Test that multiple content responses return a string representation of the list."""
+    with MCPAdapt(
+        StdioServerParameters(
+            command="uv",
+            args=["run", "python", "-c", multiple_content_server_script],
+        ),
+        CrewAIAdapter(),
+    ) as tools:
+        assert len(tools) == 1
+        tool = tools[0]
+        assert tool.name == "multiple_content_tool"
+
+        result = tool.run()
+        # Should return string representation of list of text contents
+        expected = str(["First response", "Second response", "Third response"])
+        assert result == expected


### PR DESCRIPTION
When MCP server returns multiple returns _(especially in `streamable-http` MCP servers)_, `mcpadapt` `CrewAIAdaper` only returns the first response. This minor PR collates all the responses text into a list and returns the entire response to CrewAI so it can use the entire response.

Tested with `crewai==0.165.1`

**Note**: This issue was also reported in #55 
