### PR TITLE
fix: Remove redundant $defs from outputSchema in SmolAgentsAdapter

### DIFF
--- a/src/mcpadapt/smolagents_adapter.py
+++ b/src/mcpadapt/smolagents_adapter.py
@@ -114,7 +114,11 @@ class SmolAgentsAdapter(ToolAdapter):
             and mcp_tool.outputSchema
         ):
             try:
-                output_schema = jsonref.replace_refs(mcp_tool.outputSchema)
+                output_schema = {
+                    k: v
+                    for k, v in jsonref.replace_refs(mcp_tool.outputSchema).items()
+                    if k != "$defs"
+                }
             except Exception as e:
                 logger.warning(
                     f"Failed to resolve outputSchema for tool {mcp_tool.name}: {e}"


### PR DESCRIPTION
## Problem

The `outputSchema` processing in `SmolAgentsAdapter` was inconsistent with `inputSchema` processing. While `inputSchema` correctly filters out redundant `$defs` after `jsonref.replace_refs()`, the `outputSchema` did not.

This inconsistency causes serious issues:
- Redundant `$defs` definitions consume excessive tokens in the LLM prompt, wasting valuable context window space
- Even GPT-5 cannot accurately understand the output schema when cluttered with these unnecessary definitions
- This prevents achieving the goal to ["chain multiple tool calls and directly access structured output fields in the same code block!"](https://github.com/huggingface/smolagents/blob/main/src/smolagents/prompts/code_agent.yaml#L162)

## Changes

- Updated `outputSchema` processing to filter out `$defs` key after resolving references
- Now matches the pattern used for `inputSchema` processing, ensuring consistency across the codebase